### PR TITLE
Fix memory leak issue

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -16,7 +16,12 @@ Version 1.3.1 (unreleased)
     to "script.".    
 * Added ModelScript.set/getBinding for setting script binding variables
     from embedding applications.
-
+* Made AssetReader reusable by exposing AssetReader.setAssetRoot() method. 
+    Convert now uses the same AssetReader and AssetManager and will just reset
+    the asset root path when required instead of creating a new one. This fixes
+    a memory leak issue that was happening because of native memory allocated
+    with previous asset manager instances was not being released properly for
+    some reason and was leading to an OutOfMemoryError in embedding applications.
 
 Version 1.3.0 (latest)
 --------------

--- a/src/main/java/com/simsilica/jmec/AssetReader.java
+++ b/src/main/java/com/simsilica/jmec/AssetReader.java
@@ -66,31 +66,41 @@ public class AssetReader {
     private Path root;
     private final DesktopAssetManager assets;
 
-    public AssetReader( ) {
-        this((URL) null);
+    public AssetReader() {
+        this(new File("."));
     }
 
-    public AssetReader(URL assetConfig ) {
+    public AssetReader( File assetRoot ) {
+        this(assetRoot, (URL) null);
+    }
+
+    public AssetReader( File assetRoot, URL assetConfig ) {
         if( assetConfig == null ) {
             assetConfig = getClass().getResource(DESKTOP_ASSET_CONFIG);
             log.info("Found assetConfig:" + assetConfig);
         }
 
         this.assets = new DesktopAssetManager(assetConfig);
+        setAssetRoot(assetRoot);
     }
 
-    public AssetReader(DesktopAssetManager assets) {
+    public AssetReader( File assetRoot, DesktopAssetManager assets ) {
         this.assets = assets;
+        setAssetRoot(assetRoot);
     }
 
-    public void setAssetRoot(File assetRoot) {
+    public void setAssetRoot( File assetRoot ) {
         if (root != null) {
             assets.unregisterLocator(root.toString(), FileLocator.class);
+        }
+        if (assetRoot == null) {
+            root = null;
+            return;
         }
 
         try {
             this.root = assetRoot.getCanonicalFile().toPath();
-        } catch( java.io.IOException e ) {
+        } catch (java.io.IOException e) {
             throw new RuntimeException("Error getting canonical path for:" + assetRoot, e);
         }
         log.info("Using source asset root:" + root);
@@ -98,11 +108,8 @@ public class AssetReader {
         assets.registerLocator(root.toString(), FileLocator.class);
     }
 
-    public void removeAssetRoot() {
-        if (root != null) {
-            assets.unregisterLocator(root.toString(), FileLocator.class);
-            root = null;
-        }
+    public File getAssetRoot() {
+        return root != null ? root.toFile() : null;
     }
 
     public DesktopAssetManager getAssetManager() {

--- a/src/main/java/com/simsilica/jmec/Convert.java
+++ b/src/main/java/com/simsilica/jmec/Convert.java
@@ -131,12 +131,17 @@ public class Convert {
     private List<ModelProcessor> processors = new ArrayList<>();
 
     public Convert() {
+        this(new AssetReader());
+    }
+
+    public Convert(AssetReader assets) {
+        this.assets = assets;
     }
 
     public AssetReader getAssetReader() {
-        if( assets == null ) {
+        if( sourceRoot == null ) {
             log.warn("No source root specified, using local directory.");
-            // Create something at least.
+            // Set something at least.
             setSourceRoot(new File("."));
         }
         return assets;
@@ -168,7 +173,7 @@ public class Convert {
             return;
         }
         this.sourceRoot = f;
-        this.assets = new AssetReader(f);
+        getAssetReader().setAssetRoot(f);
     }
 
     public File getSourceRoot() {

--- a/src/main/java/com/simsilica/jmec/Convert.java
+++ b/src/main/java/com/simsilica/jmec/Convert.java
@@ -134,7 +134,7 @@ public class Convert {
         this(new AssetReader());
     }
 
-    public Convert(AssetReader assets) {
+    public Convert( AssetReader assets ) {
         this.assets = assets;
     }
 


### PR DESCRIPTION
Made AssetReader reusable by exposing AssetReader.setAssetRoot() method. Convert now uses the same AssetReader and AssetManager and will just reset the asset root path when required instead of creating a new one. This fixes a memory leak issue that was happening because native memory allocated with previous asset manager instances was not being released properly and was leading to an OutOfMemoryError in embedding applications.

Details :
https://hub.jmonkeyengine.org/t/outofmemoryerror-when-converting-assets-with-jmeconver/46175